### PR TITLE
Making python nodes run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(smb_mission_planner)
 
 find_package(catkin_simple REQUIRED)
+catkin_python_setup()
 catkin_simple(ALL_DEPS_REQUIRED)
-
 cs_install()
 cs_export()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+d = generate_distutils_setup(
+    packages=['smb_mission_planner'],
+    scripts=['scripts'],
+    package_dir={'': 'src'}
+)
+
+setup(**d)


### PR DESCRIPTION
This PR fixes #1 

I never developed a ROS package using python modules so far, but by adding a `setup.py` and `catkin_python_setup()` to the CMakeLists.txt, it seems to work now. I'm not sure if the change to CMakeLists.txt is actually necessary.

Maybe there is a nicer solution to that?